### PR TITLE
Partial support of PBR materials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ thirdparty/
 bin/
 external/
 .vs/
+test*.bmp
 
 # Prerequisites
 *.d

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Study <Ray Tracing in a Weekend>
 * OS       : Windows 10, WSL
 
 # Screenshots
-![preview1](https://user-images.githubusercontent.com/11644393/51799554-8e8a9980-2265-11e9-98d4-9fde313faa11.jpg)
-![preview2](https://user-images.githubusercontent.com/11644393/51799555-90545d00-2265-11e9-83b2-248f035ab4fa.jpg)
 ![preview3](https://user-images.githubusercontent.com/11644393/51801447-49746080-2281-11e9-9d56-2954ab4039c1.jpg)
-![preview4](https://user-images.githubusercontent.com/11644393/71446509-75d17f00-2767-11ea-9fb1-dbf79bf59e9e.jpg)
 ![preview5](https://user-images.githubusercontent.com/11644393/153760159-e1e8b09c-00b9-4ca9-97c9-9e8421bbecd8.jpg)
+![preview6](https://user-images.githubusercontent.com/11644393/186878829-f7ce3927-c30e-4686-abec-94df6e6a5ccb.jpg)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,3 +25,7 @@ add_custom_command(TARGET RayTracer POST_BUILD
 	"${CMAKE_SOURCE_DIR}/thirdparty/FreeImage/binaries/FreeImage.dll"
 	$<TARGET_FILE_DIR:RayTracer>)
 	
+# TODO: This injects a hard-coded path to the executable.
+#       Moving the project to another directory will make
+#       the application fail to find shader binaries.
+add_compile_definitions(SOLUTION_DIR="${CMAKE_SOURCE_DIR}/")

--- a/src/camera.h
+++ b/src/camera.h
@@ -46,7 +46,7 @@ public:
 		vec3 rd     = lens_radius * RandomInUnitDisk();
 		vec3 offset = (u * rd.x) + (v * rd.y);
 		float captureTime = beginCapture + (endCapture - beginCapture) * Random();
-		return ray(origin + offset, top_left + s * horizontal + (1.0f - t) * vertical - origin - offset, captureTime);
+		return ray(origin + offset, normalize(top_left + s * horizontal + (1.0f - t) * vertical - origin - offset), captureTime);
 	}
 
 	vec3 origin;

--- a/src/image.h
+++ b/src/image.h
@@ -61,6 +61,11 @@ struct Pixel
 		return (A << 24) | (R << 16) | (G << 8) | B;
 	}
 
+	inline vec3 RGBToVec3() const
+	{
+		return vec3(r, g, b);
+	}
+
 };
 
 // Can be used as a 2D texture mipmap or a 2D render target

--- a/src/image.h
+++ b/src/image.h
@@ -93,4 +93,3 @@ public:
 	std::vector<Pixel> image;
 
 };
-

--- a/src/loader/obj_loader.cc
+++ b/src/loader/obj_loader.cc
@@ -235,14 +235,31 @@ void OBJLoader::ParseMaterials(const std::string& objpath, const std::vector<tin
 		LoadImage(inRawMaterials[i].emissive_texname, emissiveImage, emissiveImageValid);
 		LoadImage(inRawMaterials[i].normal_texname, normalImage, normalImageValid);
 
-		if (albedoImageValid)
+		if (!albedoImageValid)
 		{
-			outMaterials[i] = new TextureMaterial(albedoImage);
+			albedoImage.Reallocate(1, 1, Pixel(0.5f, 0.5f, 0.5f));
+			albedoImageValid = true;
 		}
-		else
+
+		PBRMaterial* M = new PBRMaterial;
+		M->SetAlbedoTexture(albedoImage);
+		if (normalImageValid)
 		{
-			// #todo-obj: Fallback material
-			outMaterials[i] = new Lambertian(vec3(0.5f, 0.5f, 0.5f));
+			M->SetNormalTexture(normalImage);
 		}
+		if (roughnessImageValid)
+		{
+			M->SetRoughnessTexture(roughnessImage);
+		}
+		if (metallicImageValid)
+		{
+			M->SetMetallicTexture(metallicImage);
+		}
+		if (emissiveImageValid)
+		{
+			M->SetEmissiveTexture(emissiveImage);
+		}
+
+		outMaterials[i] = M;
 	}
 }

--- a/src/loader/obj_loader.cc
+++ b/src/loader/obj_loader.cc
@@ -189,16 +189,53 @@ void OBJLoader::ParseMaterials(const std::string& objpath, const std::vector<tin
 	for (int32 i = 0; i < n; ++i)
 	{
 		// #todo-obj: Parse every data in the material
-		std::string albedoName = inRawMaterials[i].diffuse_texname;
-		if (albedoName.size() == 0)
-		{
-			continue;
-		}
-
-		std::string albedoFile = ResourceFinder::Get().Find(basedir + albedoName);
+		// PBR extension in tiny_obj_loader.h
+#if 0
+		real_t roughness;            // [0, 1] default 0
+		real_t metallic;             // [0, 1] default 0
+		real_t sheen;                // [0, 1] default 0
+		real_t clearcoat_thickness;  // [0, 1] default 0
+		real_t clearcoat_roughness;  // [0, 1] default 0
+		real_t anisotropy;           // aniso. [0, 1] default 0
+		real_t anisotropy_rotation;  // anisor. [0, 1] default 0
+		real_t pad0;
+		std::string roughness_texname;  // map_Pr
+		std::string metallic_texname;   // map_Pm
+		std::string sheen_texname;      // map_Ps
+		std::string emissive_texname;   // map_Ke
+		std::string normal_texname;     // norm. For normal mapping.
+#endif
 
 		Image2D albedoImage;
-		if (ImageLoader::SyncLoad(albedoFile.data(), albedoImage))
+		Image2D roughnessImage;
+		Image2D metallicImage;
+		Image2D emissiveImage;
+		Image2D normalImage;
+
+		bool albedoImageValid;
+		bool roughnessImageValid;
+		bool metallicImageValid;
+		bool emissiveImageValid;
+		bool normalImageValid;
+
+		auto LoadImage = [&basedir](const std::string& inFilename, Image2D& outImage, bool& outValid)
+		{
+			if (inFilename.size() == 0)
+			{
+				outValid = false;
+				return;
+			}
+			std::string filepath = ResourceFinder::Get().Find(basedir + inFilename);
+			outValid = ImageLoader::SyncLoad(filepath.data(), outImage);
+		};
+
+		LoadImage(inRawMaterials[i].diffuse_texname, albedoImage, albedoImageValid);
+		LoadImage(inRawMaterials[i].roughness_texname, roughnessImage, roughnessImageValid);
+		LoadImage(inRawMaterials[i].metallic_texname, metallicImage, metallicImageValid);
+		LoadImage(inRawMaterials[i].emissive_texname, emissiveImage, emissiveImageValid);
+		LoadImage(inRawMaterials[i].normal_texname, normalImage, normalImageValid);
+
+		if (albedoImageValid)
 		{
 			outMaterials[i] = new TextureMaterial(albedoImage);
 		}

--- a/src/main.cc
+++ b/src/main.cc
@@ -46,7 +46,7 @@
 #define RESULT_FILENAME         "test.bmp"
 
 // Rendering configuration
-#define SAMPLES_PER_PIXEL       1000
+#define SAMPLES_PER_PIXEL       500
 #define MAX_RECURSION           5
 #define RAY_T_MIN               0.001f
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -262,6 +262,7 @@ void GenerateCell(const WorkItemParam* param)
 	const float imageWidth = (float)cell->image->GetWidth();
 	const float imageHeight = (float)cell->image->GetHeight();
 
+	// #todo-multithread: Bad utilization of threads; Some cells might take longer than others.
 	const int32 SPP = std::max(1, SAMPLES_PER_PIXEL);
 	for(int32 y = cell->y; y < endY; ++y)
 	{

--- a/src/main.cc
+++ b/src/main.cc
@@ -37,16 +37,16 @@
 #define VIEWPORT_HEIGHT         512
 
 // Debug configuration (features under development)
-#define FAKE_SKY_LIGHT          0
+#define FAKE_SKY_LIGHT          1
 #define LOCAL_LIGHTS            1
 #define INCLUDE_TOADTTE         1
 #define INCLUDE_CUBE            1
 #define TEST_TEXTURE_MAPPING    1
 #define TEST_IMAGE_LOADER       0
-#define RESULT_FILENAME         "test.bmp"
+#define RESULT_FILENAME         SOLUTION_DIR "test.bmp"
 
 // Rendering configuration
-#define SAMPLES_PER_PIXEL       500
+#define SAMPLES_PER_PIXEL       100
 #define MAX_RECURSION           5
 #define RAY_T_MIN               0.001f
 
@@ -177,7 +177,7 @@ HitableList* CreateScene_ObjModel()
 		vec3 v1(0.0f, 0.0f, z);
 		vec3 v2(fanRadius * std::cos(fanEnd), fanRadius * std::sin(fanEnd), z);
 		vec3 n(0.0f, 0.0f, 1.0f);
-		vec3 color = vec3(0.3f, 0.3f, 0.3f) + 0.7f * RandomInUnitSphere();
+		vec3 color = vec3(0.3f, 0.3f, 0.3f) + 0.7f * RandomInHemisphere(vec3(0.0f, 0.0f, 1.0f));
 		list.push_back(new Triangle(v0, v1, v2, n, n, n, new Lambertian(color)));
 	}
 	list.push_back(new sphere(vec3(0.0f, -1000.0f, 0.0f), 1000.0f, new Lambertian(vec3(0.5f, 0.5f, 0.5f))));

--- a/src/main.cc
+++ b/src/main.cc
@@ -143,20 +143,22 @@ HitableList* CreateScene_ObjModel()
 	Image2D img;
 	if (ImageLoader::SyncLoad("content/Toadette/Toadette_body.png", img))
 	{
-		TextureMaterial* tm = new TextureMaterial(img);
+		PBRMaterial* pbr_mat = new PBRMaterial;
+		pbr_mat->SetAlbedoTexture(img);
+
 		const vec3 origin(1.0f, 0.0f, 0.0f);
 		const vec3 n(0.0f, 0.0f, 1.0f);
  		{
 			Triangle* T = new Triangle(
 				origin + vec3(0.0f, 0.0f, 0.0f), origin + vec3(1.0f, 0.0f, 0.0f), origin + vec3(1.0f, 1.0f, 0.0f),
-				n, n, n, tm);
+				n, n, n, pbr_mat);
  			T->SetParameterization(0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f);
 			list.push_back(T);
  		}
  		{
  			Triangle* T = new Triangle(
 				origin + vec3(0.0f, 0.0f, 0.0f), origin + vec3(1.0f, 1.0f, 0.0f), origin + vec3(0.0f, 1.0f, 0.0f),
-				n, n, n, tm);
+				n, n, n, pbr_mat);
  			T->SetParameterization(0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f);
 			list.push_back(T);
  		}

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -22,6 +22,16 @@ vec3 RandomInUnitSphere()
 	return vec3(r * cos(phi), r * sin(phi), z);
 }
 
+vec3 RandomInHemisphere(const vec3& axis)
+{
+	vec3 v = RandomInUnitSphere();
+	if (dot(v, axis) < 0.0)
+	{
+		v = -v;
+	}
+	return v;
+}
+
 float Random()
 {
 	static thread_local RNG randoms(4096 * 8);

--- a/src/random.h
+++ b/src/random.h
@@ -64,6 +64,8 @@ private:
 
 vec3 RandomInUnitSphere();
 
+vec3 RandomInHemisphere(const vec3& axis);
+
 float Random();
 
 vec3 RandomInUnitDisk();

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -8,6 +8,15 @@ Texture2D* Texture2D::CreateFromImage2D(const Image2D& inImage)
 	return texture;
 }
 
+Texture2D* Texture2D::CreateSolidColor(const Pixel& inColor)
+{
+	Image2D image;
+	image.Reallocate(1, 1, inColor);
+	Texture2D* texture = new Texture2D(1);
+	texture->SetData(0, image);
+	return texture;
+}
+
 Texture2D::Texture2D(uint32 numMipmaps)
 {
 	mipmaps.resize(numMipmaps);

--- a/src/texture.h
+++ b/src/texture.h
@@ -38,6 +38,8 @@ class Texture2D : public Noncopyable
 public:
 	// Create a texture from single mipmap
 	static Texture2D* CreateFromImage2D(const Image2D& inImage);
+
+	static Texture2D* CreateSolidColor(const Pixel& inColor);
 	
 public:
 	Texture2D(uint32 numMipmaps);

--- a/src/type.h
+++ b/src/type.h
@@ -113,7 +113,7 @@ inline vec3 operator-(const vec3& v1, float t)
 }
 inline vec3 operator-(float t, const vec3& v1)
 {
-	return vec3(v1.x - t, v1.y - t, v1.z - t);
+	return vec3(t - v1.x, t - v1.y, t - v1.z);
 }
 
 inline vec3 operator*(const vec3& v1, float t)
@@ -142,7 +142,7 @@ inline vec3 normalize(const vec3& v)
 
 inline vec3 mix(const vec3& v1, const vec3& v2, float a)
 {
-	return a * v1 + (1.0f - a) * v2;
+	return (1.0f - a) * v1 + a * v2;
 }
 
 inline float dot(const vec3& v1, const vec3& v2)

--- a/src/type.h
+++ b/src/type.h
@@ -37,6 +37,12 @@ class vec3
 
 public:
 	vec3() : vec3(0.0f, 0.0f, 0.0f) {}
+	vec3(float e0)
+	{
+		x = e0;
+		y = e0;
+		z = e0;
+	}
 	vec3(float e0, float e1, float e2)
 	{
 		x = e0;
@@ -132,6 +138,11 @@ inline vec3 normalize(const vec3& v)
 	vec3 u = v;
 	u.Normalize();
 	return u;
+}
+
+inline vec3 mix(const vec3& v1, const vec3& v2, float a)
+{
+	return a * v1 + (1.0f - a) * v2;
 }
 
 inline float dot(const vec3& v1, const vec3& v2)

--- a/src/util/resource_finder.cc
+++ b/src/util/resource_finder.cc
@@ -36,7 +36,9 @@ ResourceFinder& ResourceFinder::Get()
 
 ResourceFinder::ResourceFinder()
 {
+	directories.push_back(""); // For absolute path
 	directories.push_back("./");
+	directories.push_back(SOLUTION_DIR);
 }
 
 void ResourceFinder::AddDirectory(const std::string& directory)


### PR DESCRIPTION
This PR Implements basic Lambert diffuse and Cook-Torrance specular BRDF.

It's incomplete but anyway I'm merging it to `master` as I couldn't find nice Wavefront OBJ sample assets with PBR materials.

Future goal is to implement glTF loader and utilize [Khronos glTF assets](https://github.com/KhronosGroup/glTF-Sample-Models).